### PR TITLE
Remove empty div when using default mapbox markers

### DIFF
--- a/src/lib/map/Marker.svelte
+++ b/src/lib/map/Marker.svelte
@@ -56,6 +56,8 @@
       .setLngLat({ lng, lat })
       .addTo(map)
 
+    if (!element.hasChildNodes()) element.remove()
+
     return () => marker.remove()
   })
 


### PR DESCRIPTION
I'm using default mapbox markers on up to 200 markers, so there are a bunch of ugly empty divs on the mapbox-map container